### PR TITLE
Fixed a few little issues causing errors in main branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,31 +1,37 @@
-# utxo-plugin
+# utxoplugin
 
-UTXO-Plugin that generates address balances for utxo chains. Works only with [exrproxy](https://github.com/blocknetdx/exrproxy) in [Enterprise XRouter Environment](https://github.com/blocknetdx/exrproxy-env)
-
+### Deployment Process
+Within the EXR ENV, one utxo-plugin container should be deployed for each utxo coin to be indexed.
+Example docker-compose.yml entry for utxo coin, BLOCK:
 ```yaml
-  utxo_plugin_{{ daemon.coin }}:
+  utxo-plugin-block:
     image: blocknetdx/utxo-plugin:latest
     restart: unless-stopped
-    expose:
-      - 9000
-      - 8000
     environment:
-      PLUGIN_COIN: {{ daemon.coin }}
+      PLUGIN_COIN: 'BLOCK'
       PLUGIN_PORT: 8000
-      NETWORK: master
-      SKIP_COMPACT: true
-      HOST_ADDRESS: {{ daemon.ip }}
-      HOST_RPC_PORT: {{ daemon.rpcPort }}
+      DB_ENGINE: 'rocksdb'
+      NETWORK: 'mainnet'
+      SKIP_COMPACT: 'true'
+      DAEMON_ADDR: 172.31.4.37
+      DAEMON_RPC_PORT: '41414'
       RPC_USER: "${RPC_USER}"
       RPC_PASSWORD: "${RPC_PASSWORD}"
+    stop_signal: SIGINT
+    stop_grace_period: 5m
     volumes:
-      - {{ daemon.volume }}/{{ daemon.name }}/utxo_plugin_{{ daemon.coin }}:/app/plugins/utxoplugin-{{ daemon.coin }}
+      - /snode/utxoplugin-db/BLOCK:/app/plugins/utxoplugin-BLOCK
     logging:
       driver: "json-file"
       options:
         max-size: "2m"
         max-file: "10"
+    depends_on:
+      - snode
     networks:
       backend:
-        ipv4_address: {{ daemon.utxo_ip }}
+        ipv4_address: 172.31.8.23
 ```
+DAEMON_ADDR is the IP addr of the container hosting the BLOCK daemon
+
+DAEMON_RPC_PORT is the RPC port of the BLOCK daemon

--- a/main.py
+++ b/main.py
@@ -8,7 +8,6 @@ from os import environ, getcwd, mkdir, remove
 from os.path import isdir, exists
 from electrumx import Env
 from electrumx.lib.util import CompactFormatter, make_logger
-from kubernetes.config import ConfigException
 from server.db import Database
 from server.controller import Controller
 from server.utxoplugin_coins import (Coin, Blocknet, BlocknetTestnet,
@@ -103,8 +102,8 @@ def main(db_compacted=False):
 
     delete_lock_files()
 
-    coin_host_addr = environ.get('HOST_ADDRESS')
-    rpc_port = environ.get('HOST_RPC_PORT')
+    coin_host_addr = environ.get('DAEMON_ADDR')
+    rpc_port = environ.get('DAEMON_RPC_PORT')
     rpc_user = environ.get('RPC_USER')
     rpc_pass = environ.get('RPC_PASSWORD')
 

--- a/server/controller.py
+++ b/server/controller.py
@@ -11,8 +11,8 @@ from server.db import Database
 
 class Controller(ServerBase):
     async def serve(self, shutdown_event):
-        if not (0, 18, 1) <= aiorpcx_version < (0, 19):
-            raise RuntimeError('aiorpcX version 0.18.x is required')
+#        if not (0, 18, 1) <= aiorpcx_version < (0, 19):
+#            raise RuntimeError('aiorpcX version 0.18.x is required')
 
         env = self.env
         min_str, max_str = env.coin.SESSIONCLS.protocol_min_max_strings()


### PR DESCRIPTION
Originally, I had designated the `master` branch as the *golden* branch in this repo, and it was initialized to be an exact duplicate of the most recent `utxo-plugin` repo from Cloudchains. The `main` branch, which was the WIP of *desac*, was left untouched.

Fast-forward to a few days ago when @tryiou discovered that desac's `main` branch has some useful updates to `requirements.txt`, and perhaps some other enhancements which allow it to support PIVX (and probably LBC as well), whereas the `master` branch doesn't readily support PIVX (or LBC). Long story short, @tryiou found it easiest to get PIVX working by fixing a few things in the `main` branch rather than working from the `master` branch as a base. The fixes in this PR are those small fixes made by @tryiou, plus one minor change I made to make the use of the ENV variables `DAEMON_ADDR` and `DAEMON_RPC_PORT` consistent between `main` and `master` branches.

The changes in this PR have been tested both by @tryiou and myself.