### PR TITLE
fit address history for SYS

### DIFF
--- a/server/session.py
+++ b/server/session.py
@@ -701,14 +701,21 @@ class ElectrumX(SessionBase):
                         if not prev_tx:
                             continue
 
-                        prev_out_amount = prev_tx['vout'][item['vout']]['value']
-                        addrs = prev_tx['vout'][item['vout']]['scriptPubKey']['addresses']
-                        # record total sent coin if sent from one of our addresses
-                        if len(addrs) > 0:
-                            for addr in addrs:
-                                if addr in addr_lookup:
-                                    my_total_send_amount += prev_out_amount
-                                    break
+                    prev_out_amount = prev_tx['vout'][item['vout']]['value']
+                    script_pub_key = prev_tx['vout'][item['vout']]['scriptPubKey']
+                    addrs = []
+
+                    if 'addresses' in script_pub_key:
+                        addrs = script_pub_key['addresses']
+                    elif 'address' in script_pub_key:
+                        addrs = [script_pub_key['address']]
+
+                    # Record total sent coin if sent from one of our addresses
+                    if len(addrs) > 0:
+                        for addr in addrs:
+                            if addr in addr_lookup:
+                                my_total_send_amount += prev_out_amount
+                                break
 
                         total_send_amount += prev_out_amount
                         from_addresses.update(addrs)

--- a/server/session.py
+++ b/server/session.py
@@ -765,25 +765,26 @@ class ElectrumX(SessionBase):
                         
                     def get_address(p_item):
                         self.logger.debug(f"p_item['scriptPubKey']: {p_item['scriptPubKey']}")
-                        self.logger.debug(f"p_item['scriptPubKey']['address']: {p_item['scriptPubKey']['address']} {type(p_item['scriptPubKey']['address'])}")
+                        self.logger.debug(f"p_item['scriptPubKey']['address']: {p_item['scriptPubKey'].get('address')} {type(p_item['scriptPubKey'].get('address'))}")
 
-                        if 'addresses' not in p_item['scriptPubKey'] or 'address' not in p_item['scriptPubKey'] or 'type' not in p_item['scriptPubKey'] \
-                                or p_item['scriptPubKey']['type'] == 'nonstandard':
+                        if 'type' not in p_item['scriptPubKey'] or p_item['scriptPubKey']['type'] == 'nonstandard':
                             self.logger.debug("Incompatible vout address, skipping")
                             return None  # skip incompatible vout
 
-                        if isinstance(p_item['scriptPubKey']['address'], str):
-                            return p_item['scriptPubKey']['address']
+                        if 'address' in p_item['scriptPubKey']:
+                            if isinstance(p_item['scriptPubKey']['address'], str):
+                                return p_item['scriptPubKey']['address']
 
-                        if isinstance(p_item['scriptPubKey']['addresses'], str):
-                            return p_item['scriptPubKey']['addresses']
+                        if 'addresses' in p_item['scriptPubKey']:
+                            if isinstance(p_item['scriptPubKey']['addresses'], str):
+                                return p_item['scriptPubKey']['addresses']
 
-                        elif isinstance(p_item['scriptPubKey']['addresses'], list):
-                            return p_item['scriptPubKey']['addresses'][0]
+                            elif isinstance(p_item['scriptPubKey']['addresses'], list) and len(p_item['scriptPubKey']['addresses']) > 0:
+                                return p_item['scriptPubKey']['addresses'][0]
 
-                        else:
-                            self.logger.debug("No valid address found")
-                            return None
+                        self.logger.debug("No valid address found")
+                        return None
+
 
 
 

--- a/server/session.py
+++ b/server/session.py
@@ -758,6 +758,8 @@ class ElectrumX(SessionBase):
                         if 'addresses' not in p_item['scriptPubKey'] or 'type' not in p_item['scriptPubKey'] \
                                 or p_item['scriptPubKey']['type'] == 'nonstandard':
                             return None  # skip incompatible vout
+                        if isinstance(p_item['scriptPubKey']['address'], str):
+                            return p_item['scriptPubKey']['address']
                         if isinstance(p_item['scriptPubKey']['addresses'], str):
                             return p_item['scriptPubKey']['addresses']
                         elif isinstance(p_item['scriptPubKey']['addresses'], list):

--- a/server/session.py
+++ b/server/session.py
@@ -775,7 +775,7 @@ class ElectrumX(SessionBase):
                             if isinstance(p_item['scriptPubKey']['address'], str):
                                 return p_item['scriptPubKey']['address']
 
-                        if 'addresses' in p_item['scriptPubKey']:
+                        elif 'addresses' in p_item['scriptPubKey']:
                             if isinstance(p_item['scriptPubKey']['addresses'], str):
                                 return p_item['scriptPubKey']['addresses']
 

--- a/server/session.py
+++ b/server/session.py
@@ -701,24 +701,24 @@ class ElectrumX(SessionBase):
                         if not prev_tx:
                             continue
 
-                    prev_out_amount = prev_tx['vout'][item['vout']]['value']
-                    script_pub_key = prev_tx['vout'][item['vout']]['scriptPubKey']
-                    addrs = []
+                        prev_out_amount = prev_tx['vout'][item['vout']]['value']
+                        script_pub_key = prev_tx['vout'][item['vout']]['scriptPubKey']
+                        addrs = []
 
-                    if 'addresses' in script_pub_key:
-                        addrs = script_pub_key['addresses']
-                    elif 'address' in script_pub_key:
-                        addrs = [script_pub_key['address']]
+                        if 'addresses' in script_pub_key:
+                            addrs = script_pub_key['addresses']
+                        elif 'address' in script_pub_key:
+                            addrs = [script_pub_key['address']]
 
-                    # Record total sent coin if sent from one of our addresses
-                    if len(addrs) > 0:
-                        for addr in addrs:
-                            if addr in addr_lookup:
-                                my_total_send_amount += prev_out_amount
-                                break
+                        # Record total sent coin if sent from one of our addresses
+                        if len(addrs) > 0:
+                            for addr in addrs:
+                                if addr in addr_lookup:
+                                    my_total_send_amount += prev_out_amount
+                                    break
 
-                        total_send_amount += prev_out_amount
-                        from_addresses.update(addrs)
+                            total_send_amount += prev_out_amount
+                            from_addresses.update(addrs)
 
                     my_total_send_amount_running = my_total_send_amount  # track how much sent coin is left to report
                     is_sending_coin = my_total_send_amount > 0

--- a/server/session.py
+++ b/server/session.py
@@ -712,13 +712,18 @@ class ElectrumX(SessionBase):
 
                         # Record total sent coin if sent from one of our addresses
                         if len(addrs) > 0:
+                            is_my_address = False
                             for addr in addrs:
                                 if addr in addr_lookup:
                                     my_total_send_amount += prev_out_amount
+                                    is_my_address = True
                                     break
 
-                            total_send_amount += prev_out_amount
+                            if not is_my_address:
+                                total_send_amount += prev_out_amount
+
                             from_addresses.update(addrs)
+
 
                     my_total_send_amount_running = my_total_send_amount  # track how much sent coin is left to report
                     is_sending_coin = my_total_send_amount > 0

--- a/server/session.py
+++ b/server/session.py
@@ -762,23 +762,28 @@ class ElectrumX(SessionBase):
                             }, p_txid_n
                         else:
                             return None, None
-
+                        
                     def get_address(p_item):
+                        self.logger.debug(f"p_item['scriptPubKey']['address']: {p_item['scriptPubKey']['address']} {type(p_item['scriptPubKey']['address'])}")
+
                         if 'addresses' not in p_item['scriptPubKey'] or 'address' not in p_item['scriptPubKey'] or 'type' not in p_item['scriptPubKey'] \
                                 or p_item['scriptPubKey']['type'] == 'nonstandard':
+                            self.logger.debug("Incompatible vout address, skipping")
                             return None  # skip incompatible vout
-                        if 'addresses' in p_item['scriptPubKey']:
-                            self.logger.debug(f"scriptPubKey: {p_item['scriptPubKey']['addresses']} {type(p_item['scriptPubKey']['addresses'])}")
-                        if 'address' in p_item['scriptPubKey']:
-                            self.logger.debug(f"scriptPubKey: {p_item['scriptPubKey']['address']} {type(p_item['scriptPubKey']['address'])}")
+
                         if isinstance(p_item['scriptPubKey']['address'], str):
                             return p_item['scriptPubKey']['address']
+
                         if isinstance(p_item['scriptPubKey']['addresses'], str):
                             return p_item['scriptPubKey']['addresses']
+
                         elif isinstance(p_item['scriptPubKey']['addresses'], list):
                             return p_item['scriptPubKey']['addresses'][0]
+
                         else:
+                            self.logger.debug("No valid address found")
                             return None
+
 
 
                     # First pass: Only process transactions sent to another address, record fees

--- a/server/session.py
+++ b/server/session.py
@@ -767,6 +767,10 @@ class ElectrumX(SessionBase):
                         if 'addresses' not in p_item['scriptPubKey'] or 'address' not in p_item['scriptPubKey'] or 'type' not in p_item['scriptPubKey'] \
                                 or p_item['scriptPubKey']['type'] == 'nonstandard':
                             return None  # skip incompatible vout
+                        if 'addresses' in p_item['scriptPubKey']:
+                            self.logger.debug(f"scriptPubKey: {p_item['scriptPubKey']['addresses']} {type(p_item['scriptPubKey']['addresses'])}")
+                        if 'address' in p_item['scriptPubKey']:
+                            self.logger.debug(f"scriptPubKey: {p_item['scriptPubKey']['address']} {type(p_item['scriptPubKey']['address'])}")
                         if isinstance(p_item['scriptPubKey']['address'], str):
                             return p_item['scriptPubKey']['address']
                         if isinstance(p_item['scriptPubKey']['addresses'], str):
@@ -775,6 +779,7 @@ class ElectrumX(SessionBase):
                             return p_item['scriptPubKey']['addresses'][0]
                         else:
                             return None
+
 
                     # First pass: Only process transactions sent to another address, record fees
                     for item in tx['vout']:

--- a/server/session.py
+++ b/server/session.py
@@ -671,13 +671,13 @@ class ElectrumX(SessionBase):
         processed_txs = set()  # track transactions that have already been processed
         for address in addr_lookup:
             address = str(address)
-            self.logger.debug(f'Processing address: {address}')
+            #self.logger.debug(f'Processing address: {address}')
 
             try:
                 hash_x = self.session_mgr._history_address_cache[address]
-                self.logger.debug(f'Address found in cache: {hash_x}')
+                #self.logger.debug(f'Address found in cache: {hash_x}')
             except KeyError:
-                self.logger.debug(f'Address not found in cache, converting address to hashX')
+                #self.logger.debug(f'Address not found in cache, converting address to hashX')
                 try:
                     hash_x = self.coin.address_to_hashX(address)
                     self.session_mgr._history_address_cache[address] = hash_x
@@ -688,16 +688,16 @@ class ElectrumX(SessionBase):
 
             try:
                 history = await self.db.limited_history(hash_x, limit=100)
-                self.logger.debug(f'History retrieved for address: {address}')
+                #self.logger.debug(f'History retrieved for address: {address}')
 
                 for tx_hash, height in history:
                     if tx_hash in processed_txs:
-                        self.logger.debug(f'Skipping transaction, already processed: {tx_hash}')
+                        #self.logger.debug(f'Skipping transaction, already processed: {tx_hash}')
                         continue  # skip, already processed
-                    self.logger.debug(f'Processing transaction: {tx_hash}')
+                    #self.logger.debug(f'Processing transaction: {tx_hash}')
                     tx = await self.transaction_get(hash_to_hex_str(tx_hash), verbose=True)
                     if not tx:
-                        self.logger.debug(f'Transaction not found: {tx_hash}')
+                        #self.logger.debug(f'Transaction not found: {tx_hash}')
                         continue
                     processed_txs.add(tx_hash)
 
@@ -764,11 +764,11 @@ class ElectrumX(SessionBase):
                             return None, None
                         
                     def get_address(p_item):
-                        self.logger.debug(f"p_item['scriptPubKey']: {p_item['scriptPubKey']}")
-                        self.logger.debug(f"p_item['scriptPubKey']['address']: {p_item['scriptPubKey'].get('address')} {type(p_item['scriptPubKey'].get('address'))}")
+                        #self.logger.debug(f"p_item['scriptPubKey']: {p_item['scriptPubKey']}")
+                        #self.logger.debug(f"p_item['scriptPubKey']['address']: {p_item['scriptPubKey'].get('address')} {type(p_item['scriptPubKey'].get('address'))}")
 
                         if 'type' not in p_item['scriptPubKey'] or p_item['scriptPubKey']['type'] == 'nonstandard':
-                            self.logger.debug("Incompatible vout address, skipping")
+                            #self.logger.debug("Incompatible vout address, skipping")
                             return None  # skip incompatible vout
 
                         if 'address' in p_item['scriptPubKey']:
@@ -782,7 +782,7 @@ class ElectrumX(SessionBase):
                             elif isinstance(p_item['scriptPubKey']['addresses'], list) and len(p_item['scriptPubKey']['addresses']) > 0:
                                 return p_item['scriptPubKey']['addresses'][0]
 
-                        self.logger.debug("No valid address found")
+                        #self.logger.debug("No valid address found")
                         return None
 
 
@@ -795,11 +795,11 @@ class ElectrumX(SessionBase):
                         fees += amount
                         vout_address = get_address(item)
                         if not vout_address:
-                            self.logger.debug('Incompatible vout address, skipping')
+                            #self.logger.debug('Incompatible vout address, skipping')
                             continue  # incompatible address, skip
 
                         if vout_address in addr_lookup:
-                            self.logger.debug('Address is not ours, skipping')
+                            #self.logger.debug('Address is not ours, skipping')
                             continue  # not our address, skip
 
                         # Amount is negative for send and positive for receive
@@ -819,16 +819,16 @@ class ElectrumX(SessionBase):
                             if spend:
                                 spent_ids.add(txid_n)
                                 spends.append(spend)
-                                self.logger.debug(f'Spent coin recorded: {spend}')
+                                #self.logger.debug(f'Spent coin recorded: {spend}')
 
                     # Second pass: Only process transactions for all our own addresses
                     for item in tx['vout']:
                         vout_address = get_address(item)
                         if not vout_address:
-                            self.logger.debug('Incompatible vout address, skipping')
+                            #self.logger.debug('Incompatible vout address, skipping')
                             continue  # incompatible address, skip
                         if vout_address not in addr_lookup:
-                            self.logger.debug('Address already processed in a previous pass, skipping')
+                            #self.logger.debug('Address already processed in a previous pass, skipping')
                             continue  # skip, already processed in block above
 
                         amount = item['value']
@@ -843,7 +843,7 @@ class ElectrumX(SessionBase):
                         if spend:
                             spent_ids.add(txid_n)
                             spends.append(spend)
-                            self.logger.debug(f'Received coin recorded: {spend}')
+                            #self.logger.debug(f'Received coin recorded: {spend}')
 
                         # Amount is negative for send and positive for receive
                         # Record sent coin to address if we have outstanding send amount.
@@ -860,7 +860,7 @@ class ElectrumX(SessionBase):
                                 if spend:
                                     spent_ids.add(txid_n)
                                     spends.append(spend)
-                                    self.logger.debug(f'Spent coin recorded: {spend}')
+                                    #self.logger.debug(f'Spent coin recorded: {spend}')
 
                                     if biggest_sent_amount_my_address < amount:
                                         biggest_sent_amount_my_address = amount
@@ -875,7 +875,7 @@ class ElectrumX(SessionBase):
                                 if biggest_sent_amount_not_my_address > 0 else biggest_sent_address_my_address
                             if spend['address'] == biggest_sent_address and spend['category'] == 'send':
                                 spend['fee'] = truncate(fees, 10)
-                                self.logger.debug(f'Assigned fee: {spend}')
+                                #self.logger.debug(f'Assigned fee: {spend}')
                                 break
 
                     # Consolidate spends to self
@@ -916,7 +916,7 @@ class ElectrumX(SessionBase):
                             spend['time'] = blocktime
 
                     spent.extend(spends)
-                    self.logger.debug(f'Spends recorded for transaction: {spends}')
+                    #self.logger.debug(f'Spends recorded for transaction: {spends}')
 
             except Exception:
                 self.logger.exception('[GetAddressHistory] Exception while retrieving history')

--- a/server/session.py
+++ b/server/session.py
@@ -681,7 +681,7 @@ class ElectrumX(SessionBase):
                 try:
                     hash_x = self.coin.address_to_hashX(address)
                     self.session_mgr._history_address_cache[address] = hash_x
-                    self.logger.debug(f'Address converted to hashX: {hash_x}')
+                    #self.logger.debug(f'Address converted to hashX: {hash_x}')
                 except Exception:
                     self.logger.exception('[GetAddressHistory] Exception while converting address')
                     continue
@@ -708,7 +708,7 @@ class ElectrumX(SessionBase):
                     for item in tx['vin']:
                         prev_tx = await self.transaction_get(item['txid'], verbose=True)
                         if not prev_tx:
-                            self.logger.debug(f'Previous transaction not found: {item["txid"]}')
+                            #self.logger.debug(f'Previous transaction not found: {item["txid"]}')
                             continue
 
                         prev_out_amount = prev_tx['vout'][item['vout']]['value']

--- a/server/session.py
+++ b/server/session.py
@@ -764,7 +764,7 @@ class ElectrumX(SessionBase):
                             return None, None
 
                     def get_address(p_item):
-                        if 'addresses' not in p_item['scriptPubKey'] or 'type' not in p_item['scriptPubKey'] \
+                        if 'addresses' not in p_item['scriptPubKey'] or 'address' not in p_item['scriptPubKey'] or 'type' not in p_item['scriptPubKey'] \
                                 or p_item['scriptPubKey']['type'] == 'nonstandard':
                             return None  # skip incompatible vout
                         if isinstance(p_item['scriptPubKey']['address'], str):

--- a/server/session.py
+++ b/server/session.py
@@ -764,6 +764,7 @@ class ElectrumX(SessionBase):
                             return None, None
                         
                     def get_address(p_item):
+                        self.logger.debug(f"p_item['scriptPubKey']: {p_item['scriptPubKey']}")
                         self.logger.debug(f"p_item['scriptPubKey']['address']: {p_item['scriptPubKey']['address']} {type(p_item['scriptPubKey']['address'])}")
 
                         if 'addresses' not in p_item['scriptPubKey'] or 'address' not in p_item['scriptPubKey'] or 'type' not in p_item['scriptPubKey'] \


### PR DESCRIPTION
SYScoin have different syntax in rawtransaction,

the field 'addresses', list of string, is missing, replaced by 'address', string,

that was breaking the "async def get_address_history(self, addresses)" function,
https://github.com/blocknetdx/utxo-plugin/blob/main/server/session.py#L705
fixed code to handle this case, without breaking existing,

tested on SYS for changing syntax, now working,
and BLOCK to confirm it didn't break regular behavior, working fine.

i kept some commented logging.debug in case we need to get back at it someday.